### PR TITLE
update xai-comp contributing guide

### DIFF
--- a/docs/main/developer-guide/contributing/contributing-a-xircuits-component-library.md
+++ b/docs/main/developer-guide/contributing/contributing-a-xircuits-component-library.md
@@ -51,8 +51,9 @@ echo '{"path": "xai_components/xai-yourlib", "url": "https://github.com/your_use
 
 :::info
 
-Ensure you use the folder name format `xai_<library>`, for example `xai_yourlib`, so Xircuits can locate it.
+Don't forget that you should prepend `xai_` to the directory name in order for your component library to be parsed by the Xircuits component tray. So if your repository name is `xai-sample-library`, please convert the hyphen ( - ) to underscore ( _ ).
 
+:::
 
 Once added, commit your change:
 


### PR DESCRIPTION
# Description

update xai-comp contributing guide to use the xai-components-manifest instead of submodules approach

## References

If applicable, note issue numbers this pull request addresses. You can also note any other pull requests that address this issue and how this pull request is different.

## Pull Request Type

- [ ] Frontend (HTML / CSS / TS)
- [x] Xircuits Documentation (Tutorials, Guides, References)
- [ ] Examples (Component libraries, project templates)
- [ ] Others (Please Specify)

## Type of Change

- [ ] Frontend (HTML / CSS / TS)
- [ ] New documentation (Entirely new documentation files)
- [x] Updates to current documentation
- [ ] Minor grammar fixes

# Notes

Add if any.
