### PR TITLE
[codex] Deploy documentation with GitHub Pages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,30 +2,25 @@ name: Publish Site
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
-
-      - name: Install SSH Key
-        uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ secrets.SSH_KEY }}
-          known_hosts: 'placeholder'
-
-      - name: Adding Known Hosts
-        run: ssh-keyscan -H ${{ secrets.SSH_HOST }} >> ~/.ssh/known_hosts
+      - name: Check out repository
+        uses: actions/checkout@v6
 
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
-          cache: 'yarn'
+          node-version: "22"
+          cache: "yarn"
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -37,5 +32,28 @@ jobs:
           VECTO_USER_TOKEN: ${{ secrets.VECTO_USER_TOKEN }}
           VECTO_SPACE_ID: ${{ secrets.VECTO_SPACE_ID }}
 
-      - name: Copying to xircuits.io
-        run: rsync -a -v -h build/ ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:/var/www/xircuits.io/ --delete
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: build
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    concurrency:
+      group: pages
+      cancel-in-progress: false
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -5,7 +5,7 @@ const {themes: prismThemes} = require('prism-react-renderer');
 const config = {
   title: 'Xircuits',
   tagline: 'Xpress your Workflows',
-  url: 'http://xircuits.io',
+  url: 'https://xircuits.io',
   baseUrl: '/',
   onBrokenLinks: 'throw',
   favicon: 'img/xpress-logo.ico',


### PR DESCRIPTION
Welcome to Xircuits.io! Thank you for making a pull request. Please ensure that your pull request follows the template.

# Description

Replace the SSH/rsync publication step with GitHub Pages while retaining the existing Docusaurus 3 build, Node 22/Yarn setup, lockfile install, and Vecto indexing secrets.

The workflow now uploads the existing `build/` directory as a Pages artifact and deploys it from a separately permissioned `github-pages` job. The Docusaurus canonical URL is also changed from `http://xircuits.io` to `https://xircuits.io`.

No documentation content, navigation, styling, or search configuration changes are included.

## References

This follows the same hosting model as XpressAI/xaibo#40, adapted to this repository's Docusaurus build.

## Pull Request Type

- [ ] Frontend (HTML / CSS / TS)
- [ ] Xircuits Documentation (Tutorials, Guides, References)
- [ ] Examples (Component libraries, project templates)
- [x] Others (CI/deployment and site metadata)

## Type of Change

- [ ] Frontend (HTML / CSS / TS)
- [ ] New documentation (Entirely new documentation files)
- [x] Updates to current documentation
- [ ] Minor grammar fixes

# Notes

## Validation

- `yarn install --frozen-lockfile`
- Docusaurus client and server production bundles compile successfully
- generated artifact contains a root `index.html`, 523 files, and HTTPS canonical links
- `actionlint .github/workflows/publish.yml`
- [GitHub Actions Validate Build](https://github.com/XpressAI/xircuits.io/actions/runs/31701080747/job/94450118685): passed, including Vecto indexing with repository secrets

The standalone `yarn typecheck` command has pre-existing configuration errors because `tsconfig.json` extends a package path that is not installed; this PR does not alter TypeScript configuration.

## One-time cutover

Before merging:

1. In **Settings → Pages**, select **GitHub Actions** as the publishing source.

After the first successful deployment:

1. Verify `xircuits.io` for the XpressAI organization and set `xircuits.io` as this repository's Pages custom domain.
2. Replace the current apex DNS record with GitHub Pages' A records:
   - `185.199.108.153`
   - `185.199.109.153`
   - `185.199.110.153`
   - `185.199.111.153`
3. Point `www` via CNAME to `xpressai.github.io`.
4. Enable **Enforce HTTPS** after certificate provisioning.
5. Remove the obsolete SSH deployment secrets and revoke the old deployment key after DNS cutover is verified.
